### PR TITLE
Add downtime tracking and dashboard metrics

### DIFF
--- a/status_monitor/.gitignore
+++ b/status_monitor/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 migrations/
+!monitor/migrations/
+!monitor/migrations/*.py
 .env

--- a/status_monitor/monitor/migrations/0001_initial.py
+++ b/status_monitor/monitor/migrations/0001_initial.py
@@ -1,0 +1,96 @@
+# Generated manually by ChatGPT
+from django.db import migrations, models
+import django.utils.timezone
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Server',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255, unique=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='System',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255, unique=True)),
+                ('url', models.URLField(max_length=200)),
+                (
+                    'server',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='systems',
+                        to='monitor.server',
+                    ),
+                ),
+            ],
+        ),
+        migrations.CreateModel(
+            name='SystemDowntime',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('status', models.CharField(max_length=20)),
+                ('started_at', models.DateTimeField(default=django.utils.timezone.now)),
+                ('ended_at', models.DateTimeField(blank=True, null=True)),
+                (
+                    'system',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='downtimes',
+                        to='monitor.system',
+                    ),
+                ),
+            ],
+            options={
+                'ordering': ['-started_at'],
+            },
+        ),
+        migrations.CreateModel(
+            name='SystemStatus',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('status', models.CharField(max_length=20)),
+                ('status_code', models.IntegerField(blank=True, null=True)),
+                ('checked_at', models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    'system',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='current_status',
+                        to='monitor.system',
+                    ),
+                ),
+            ],
+            options={
+                'ordering': ['system__name'],
+            },
+        ),
+        migrations.CreateModel(
+            name='SystemStatusHistory',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('status', models.CharField(max_length=20)),
+                ('status_code', models.IntegerField(blank=True, null=True)),
+                ('checked_at', models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    'system',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='status_history',
+                        to='monitor.system',
+                    ),
+                ),
+            ],
+            options={
+                'ordering': ['-checked_at'],
+            },
+        ),
+    ]

--- a/status_monitor/monitor/models.py
+++ b/status_monitor/monitor/models.py
@@ -1,16 +1,63 @@
 from django.db import models
+from django.utils import timezone
 
-# Create your models here.
+
 class Server(models.Model):
     name = models.CharField(max_length=255, unique=True)
-    
-    def __str__(self):
+
+    def __str__(self) -> str:
         return self.name
+
 
 class System(models.Model):
     name = models.CharField(max_length=255, unique=True)
     url = models.URLField(max_length=200)
-    server = models.ForeignKey(Server, on_delete=models.CASCADE, related_name='systems')
-    
-    def __str__(self):
+    server = models.ForeignKey(Server, on_delete=models.CASCADE, related_name="systems")
+
+    def __str__(self) -> str:
         return self.name
+
+
+class SystemStatus(models.Model):
+    system = models.OneToOneField(System, on_delete=models.CASCADE, related_name="current_status")
+    status = models.CharField(max_length=20)
+    status_code = models.IntegerField(null=True, blank=True)
+    checked_at = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        ordering = ["system__name"]
+
+    def __str__(self) -> str:
+        return f"{self.system.name}: {self.status}"
+
+
+class SystemStatusHistory(models.Model):
+    system = models.ForeignKey(System, on_delete=models.CASCADE, related_name="status_history")
+    status = models.CharField(max_length=20)
+    status_code = models.IntegerField(null=True, blank=True)
+    checked_at = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        ordering = ["-checked_at"]
+
+    def __str__(self) -> str:
+        return f"{self.system.name} @ {self.checked_at:%Y-%m-%d %H:%M:%S}: {self.status}"
+
+
+class SystemDowntime(models.Model):
+    system = models.ForeignKey(System, on_delete=models.CASCADE, related_name="downtimes")
+    status = models.CharField(max_length=20)
+    started_at = models.DateTimeField(default=timezone.now)
+    ended_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["-started_at"]
+
+    def __str__(self) -> str:
+        end = self.ended_at.strftime("%Y-%m-%d %H:%M:%S") if self.ended_at else "em aberto"
+        return f"{self.system.name} ({self.status}) de {self.started_at:%Y-%m-%d %H:%M:%S} até {end}"
+
+    @property
+    def duration(self):
+        end_time = self.ended_at or timezone.now()
+        return end_time - self.started_at

--- a/status_monitor/monitor/static/scripts.js
+++ b/status_monitor/monitor/static/scripts.js
@@ -1,124 +1,439 @@
-function createSystemCard(system, status = 'loading') {
-            const card = document.createElement('div');
-            card.className = `system-card ${status}`;
-            card.innerHTML = `
-                <div class="system-name">${system.name}</div>
-                <div class="system-status">${status.toUpperCase()}</div>
-                <a href="${system.url}" target="_blank" class="system-url">Link</a>
-                <div class="system-timestamp"></div>
-                ${status === 'loading' ? '<div class="loading-bar"></div>' : ''}
-            `;
-            return card;
-        }
+const REFRESH_INTERVAL = 15 * 60 * 1000; // 15 minutos
+const STORAGE_KEY = 'monitorState';
 
-        async function updateSystemStatus(card, system) {
-            try {
-                const response = await fetch(`/system_status/?url=${encodeURIComponent(system.url)}&name=${encodeURIComponent(system.name)}`);
-                const data = await response.json();
+let monitorState = null;
+let refreshTimeoutId = null;
+let downtimeChart = null;
 
-                // Converte a string de status para uma classe CSS válida (ex: "NOT FOUND" -> "not-found")
-                const statusClass = data.status.toLowerCase().replace(/\s+/g, '-');
+function getDefaultState() {
+    return {
+        servers: {},
+        statuses: {},
+        counts: {
+            active: 0,
+            forbidden: 0,
+            down: 0,
+        },
+        chartData: [],
+        detailAnchor: '#main-container',
+        nextRefreshAt: null,
+        lastUpdated: null,
+    };
+}
 
-                card.className = `system-card ${statusClass}`;
-                card.querySelector('.system-status').textContent = data.status;
-                card.querySelector('.system-timestamp').textContent = `Última verificação: ${data.checked_at}`;
-                const loadingBar = card.querySelector('.loading-bar');
-                if (loadingBar) {
-                    loadingBar.remove();
-                }
-            
-            } catch (error) {
-                card.className = 'system-card down';
-                card.querySelector('.system-status').textContent = 'ERRO';
+function loadStateFromStorage() {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(stored);
+        return {
+            ...getDefaultState(),
+            ...parsed,
+            servers: parsed.servers || {},
+            statuses: parsed.statuses || {},
+            counts: {
+                ...getDefaultState().counts,
+                ...(parsed.counts || {}),
+            },
+            chartData: parsed.chartData || [],
+        };
+    } catch (error) {
+        console.warn('Não foi possível carregar o estado salvo:', error);
+        return null;
+    }
+}
+
+function persistState() {
+    if (!monitorState) {
+        return;
+    }
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(monitorState));
+}
+
+function makeSafeId(value) {
+    return value.toLowerCase().replace(/[^a-z0-9]+/gi, '-');
+}
+
+function escapeSelector(value) {
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+        return window.CSS.escape(value);
+    }
+    return value.replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+}
+
+function getStatusClass(status) {
+    if (!status) {
+        return 'other';
+    }
+    const normalized = status.toLowerCase().replace(/\s+/g, '-');
+    if (['up', 'down', 'forbidden', 'loading'].includes(normalized)) {
+        return normalized;
+    }
+    return normalized || 'other';
+}
+
+function formatTimestamp(date = new Date()) {
+    return date.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function applyStatusToCard(card, data) {
+    const statusText = data.status || 'DESCONHECIDO';
+    const statusClass = getStatusClass(statusText);
+
+    card.className = `system-card ${statusClass}`;
+
+    const statusElement = card.querySelector('.system-status');
+    if (statusElement) {
+        statusElement.textContent = statusText;
+    }
+
+    const timestampElement = card.querySelector('.system-timestamp');
+    if (timestampElement) {
+        timestampElement.textContent = data.checked_at
+            ? `Última verificação: ${data.checked_at}`
+            : '';
+    }
+
+    const loadingBar = card.querySelector('.loading-bar');
+    if (loadingBar) {
+        loadingBar.remove();
+    }
+}
+
+function createSystemCard(system, statusData = null) {
+    const statusText = statusData?.status || 'CARREGANDO';
+    const statusClass = statusData ? getStatusClass(statusText) : 'loading';
+
+    const card = document.createElement('div');
+    card.className = `system-card ${statusClass}`;
+    card.dataset.systemName = system.name;
+
+    const timestampText = statusData?.checked_at
+        ? `Última verificação: ${statusData.checked_at}`
+        : '';
+
+    card.innerHTML = `
+        <div class="system-name">${system.name}</div>
+        <div class="system-status">${statusText}</div>
+        <a href="${system.url}" target="_blank" class="system-url" rel="noopener">Link</a>
+        <div class="system-timestamp">${timestampText}</div>
+        ${statusData ? '' : '<div class="loading-bar"></div>'}
+    `;
+
+    if (statusData) {
+        applyStatusToCard(card, statusData);
+    }
+
+    return card;
+}
+
+function ingestServerStatuses(servers) {
+    Object.values(servers).forEach((systems) => {
+        systems.forEach((system) => {
+            if (system.status) {
+                monitorState.statuses[system.name] = {
+                    status: system.status,
+                    checked_at: system.checked_at,
+                };
             }
-        }
+        });
+    });
+}
 
-        async function loadSystems() {
-            const container = document.getElementById('main-container');
-            try {
-                const response = await fetch('/systems_list/');
-                const servers = await response.json();
+function renderServers(servers) {
+    const container = document.getElementById('main-container');
+    if (!container) {
+        return;
+    }
 
-                container.innerHTML = ''; // Limpa o container antes de adicionar os painéis
-            
-                for (const serverName in servers) {
-                    const systems = servers[serverName];
+    container.innerHTML = '';
 
-                    // Cria o painel para o servidor
-                    const panel = document.createElement('div');
-                    panel.className = 'systems-panel';
-                
-                    // Adiciona o título do servidor
-                    const title = document.createElement('h2');
-                    title.className = 'server-title';
-                    title.textContent = serverName;
-                    panel.appendChild(title);
+    Object.entries(servers).forEach(([serverName, systems]) => {
+        const panel = document.createElement('div');
+        panel.className = 'systems-panel';
 
-                    // Adiciona o container de filtros
-                    const filterContainer = document.createElement('div');
-                    filterContainer.className = 'filter-container';
-                    filterContainer.innerHTML = `
-                        <input type="text" id="searchInput-${serverName}" onkeyup="filterSystems('${serverName}')" placeholder="Buscar por nome...">
-                        <button onclick="filterByStatus('down', '${serverName}')">DOWN</button>
-                        <button onclick="filterByStatus('forbidden', '${serverName}')">FORBIDDEN</button>
-                        <button onclick="filterByStatus('', '${serverName}')">Limpar</button>
-                    `;
-                    panel.appendChild(filterContainer);
-                
-                    // Cria a grade de sistemas
-                    const grid = document.createElement('div');
-                    grid.className = 'systems-grid';
-                    grid.id = `systems-grid-${serverName}`;
-                    panel.appendChild(grid);
-                
-                    // Adiciona o painel completo ao container principal
-                    container.appendChild(panel);
+        const title = document.createElement('h2');
+        title.className = 'server-title';
+        title.textContent = serverName;
+        panel.appendChild(title);
 
-                    // Popula a grade com os sistemas
-                    if (systems.length > 0) {
-                        systems.forEach(system => {
-                            const card = createSystemCard(system);
-                            grid.appendChild(card);
-                            updateSystemStatus(card, system);
-                        });
-                    } else {
-                        grid.innerHTML = '<div>Nenhum sistema para monitorar neste servidor.</div>';
-                    }
-                }
-            } catch (error) {
-                container.innerHTML = '<div class="system-card down">Erro ao carregar a lista de servidores</div>';
-            }
-        }
+        const safeId = makeSafeId(serverName);
 
-        function filterSystems(serverName) {
-            const input = document.getElementById(`searchInput-${serverName}`);
-            const filter = input.value.toUpperCase();
-            const grid = document.getElementById(`systems-grid-${serverName}`);
-            const cards = grid.getElementsByClassName('system-card');
+        const filterContainer = document.createElement('div');
+        filterContainer.className = 'filter-container';
+        filterContainer.innerHTML = `
+            <input type="text" id="searchInput-${safeId}" onkeyup="filterSystems('${safeId}')" placeholder="Buscar por nome...">
+            <button onclick="filterByStatus('down', '${safeId}')">DOWN</button>
+            <button onclick="filterByStatus('forbidden', '${safeId}')">FORBIDDEN</button>
+            <button onclick="filterByStatus('', '${safeId}')">Limpar</button>
+        `;
+        panel.appendChild(filterContainer);
 
-            for (let i = 0; i < cards.length; i++) {
-                const name = cards[i].getElementsByClassName('system-name')[0];
-                if (name.innerHTML.toUpperCase().indexOf(filter) > -1) {
-                    cards[i].style.display = "";
-                } else {
-                    cards[i].style.display = "none";
-                }
-            }
-        }
+        const grid = document.createElement('div');
+        grid.className = 'systems-grid';
+        grid.id = `systems-grid-${safeId}`;
+        panel.appendChild(grid);
 
-        function filterByStatus(status, serverName) {
-            const grid = document.getElementById(`systems-grid-${serverName}`);
-            const cards = grid.getElementsByClassName('system-card');
+        systems.forEach((system) => {
+            const cachedStatus = monitorState.statuses[system.name];
+            const card = createSystemCard(system, cachedStatus);
+            grid.appendChild(card);
+        });
 
-            for (let i = 0; i < cards.length; i++) {
-                if (status === '' || cards[i].classList.contains(status)) {
-                    cards[i].style.display = "";
-                } else {
-                    cards[i].style.display = "none";
-                }
-            }
-        }
+        container.appendChild(panel);
+    });
+}
 
+function updateDashboardCards(counts) {
+    const activeElement = document.getElementById('active-count');
+    const forbiddenElement = document.getElementById('forbidden-count');
+    const downElement = document.getElementById('down-count');
+
+    if (activeElement) {
+        activeElement.textContent = counts?.active ?? 0;
+    }
+    if (forbiddenElement) {
+        forbiddenElement.textContent = counts?.forbidden ?? 0;
+    }
+    if (downElement) {
+        downElement.textContent = counts?.down ?? 0;
+    }
+}
+
+function renderDowntimeChart(data) {
+    const canvas = document.getElementById('downtime-chart');
+    if (!canvas || typeof Chart === 'undefined') {
+        return;
+    }
+
+    const labels = data.map((item) => item.name);
+    const durations = data.map((item) => item.total_minutes);
+
+    if (downtimeChart) {
+        downtimeChart.data.labels = labels;
+        downtimeChart.data.datasets[0].data = durations;
+        downtimeChart.update();
+        return;
+    }
+
+    downtimeChart = new Chart(canvas, {
+        type: 'bar',
+        data: {
+            labels,
+            datasets: [
+                {
+                    data: durations,
+                    backgroundColor: '#dc3545',
+                    borderRadius: 6,
+                },
+            ],
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    display: false,
+                },
+                tooltip: {
+                    callbacks: {
+                        label: (context) => `${context.parsed.y} min`,
+                    },
+                },
+            },
+            scales: {
+                x: {
+                    ticks: {
+                        autoSkip: false,
+                        maxRotation: 45,
+                        minRotation: 0,
+                    },
+                },
+                y: {
+                    beginAtZero: true,
+                    title: {
+                        display: true,
+                        text: 'Minutos',
+                    },
+                },
+            },
+        },
+    });
+}
+
+function updateDetailLink(anchor) {
+    const detailLink = document.getElementById('detail-link');
+    if (!detailLink) {
+        return;
+    }
+    detailLink.href = anchor || '#main-container';
+}
+
+function scheduleNextLoad(delay) {
+    if (refreshTimeoutId) {
+        clearTimeout(refreshTimeoutId);
+    }
+    refreshTimeoutId = setTimeout(() => {
         loadSystems();
-        // setInterval(loadSystems, 60000);
-        setInterval(loadSystems,  (15 * 60) * 1000); // (15 minutos)
+    }, delay);
+}
+
+function getCardElement(systemName) {
+    const selectorName = escapeSelector(systemName);
+    return document.querySelector(`.system-card[data-system-name="${selectorName}"]`);
+}
+
+async function updateSystemStatus(card, system) {
+    try {
+        const response = await fetch(`/system_status/?url=${encodeURIComponent(system.url)}&name=${encodeURIComponent(system.name)}`);
+        if (!response.ok) {
+            throw new Error('Falha ao consultar status do sistema');
+        }
+        const data = await response.json();
+        applyStatusToCard(card, data);
+        monitorState.statuses[system.name] = data;
+        persistState();
+        return data;
+    } catch (error) {
+        console.error(`Erro ao atualizar o status de ${system.name}:`, error);
+        const fallback = {
+            status: 'ERRO',
+            checked_at: formatTimestamp(),
+        };
+        applyStatusToCard(card, fallback);
+        monitorState.statuses[system.name] = fallback;
+        persistState();
+        return fallback;
+    }
+}
+
+async function loadDashboardSummary() {
+    try {
+        const response = await fetch('/dashboard_summary/');
+        if (!response.ok) {
+            throw new Error('Falha ao carregar o resumo');
+        }
+        const data = await response.json();
+        monitorState.counts = data.counts || monitorState.counts;
+        monitorState.chartData = data.downtime_chart || [];
+        monitorState.detailAnchor = data.detail_anchor || '#main-container';
+        persistState();
+        updateDashboardCards(monitorState.counts);
+        renderDowntimeChart(monitorState.chartData);
+        updateDetailLink(monitorState.detailAnchor);
+    } catch (error) {
+        console.error('Erro ao carregar resumo do dashboard:', error);
+    }
+}
+
+async function loadSystems() {
+    const container = document.getElementById('main-container');
+    if (!container) {
+        return;
+    }
+
+    try {
+        const response = await fetch('/systems_list/');
+        if (!response.ok) {
+            throw new Error('Falha ao carregar a lista de sistemas');
+        }
+        const servers = await response.json();
+        monitorState.servers = servers;
+        ingestServerStatuses(servers);
+        persistState();
+
+        renderServers(servers);
+
+        const statusPromises = [];
+        Object.values(servers).forEach((systems) => {
+            systems.forEach((system) => {
+                const card = getCardElement(system.name);
+                if (card) {
+                    statusPromises.push(updateSystemStatus(card, system));
+                }
+            });
+        });
+
+        await Promise.all(statusPromises);
+        await loadDashboardSummary();
+
+        monitorState.lastUpdated = new Date().toISOString();
+        monitorState.nextRefreshAt = Date.now() + REFRESH_INTERVAL;
+        persistState();
+
+        scheduleNextLoad(REFRESH_INTERVAL);
+    } catch (error) {
+        console.error('Erro ao carregar sistemas:', error);
+        container.innerHTML = '<div class="system-card down">Erro ao carregar a lista de servidores</div>';
+    }
+}
+
+function renderFromState() {
+    if (!monitorState) {
+        return;
+    }
+    if (monitorState.servers && Object.keys(monitorState.servers).length > 0) {
+        renderServers(monitorState.servers);
+    }
+    updateDashboardCards(monitorState.counts);
+    renderDowntimeChart(monitorState.chartData);
+    updateDetailLink(monitorState.detailAnchor);
+}
+
+function initializeDashboard() {
+    monitorState = loadStateFromStorage() || getDefaultState();
+    renderFromState();
+
+    const now = Date.now();
+    if (monitorState.nextRefreshAt && monitorState.nextRefreshAt > now) {
+        scheduleNextLoad(monitorState.nextRefreshAt - now);
+    } else {
+        loadSystems();
+    }
+}
+
+function filterSystems(serverId) {
+    const input = document.getElementById(`searchInput-${serverId}`);
+    const filter = (input?.value || '').toUpperCase();
+    const grid = document.getElementById(`systems-grid-${serverId}`);
+    if (!grid) {
+        return;
+    }
+
+    const cards = grid.getElementsByClassName('system-card');
+    Array.from(cards).forEach((card) => {
+        const nameElement = card.getElementsByClassName('system-name')[0];
+        if (!nameElement) {
+            card.style.display = 'none';
+            return;
+        }
+        if (nameElement.innerHTML.toUpperCase().includes(filter)) {
+            card.style.display = '';
+        } else {
+            card.style.display = 'none';
+        }
+    });
+}
+
+function filterByStatus(status, serverId) {
+    const grid = document.getElementById(`systems-grid-${serverId}`);
+    if (!grid) {
+        return;
+    }
+    const cards = grid.getElementsByClassName('system-card');
+    Array.from(cards).forEach((card) => {
+        if (!status || card.classList.contains(status)) {
+            card.style.display = '';
+        } else {
+            card.style.display = 'none';
+        }
+    });
+}
+
+window.filterSystems = filterSystems;
+window.filterByStatus = filterByStatus;
+
+document.addEventListener('DOMContentLoaded', initializeDashboard);

--- a/status_monitor/monitor/static/styles.css
+++ b/status_monitor/monitor/static/styles.css
@@ -13,6 +13,119 @@ body {
     background-color: #f8f9fa;
 }
 
+main {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+}
+
+.dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    padding: 20px;
+    max-width: 1200px;
+    width: 100%;
+    margin: 0 auto;
+}
+
+.dashboard-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+}
+
+.dashboard-card {
+    background: white;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-height: 140px;
+}
+
+.dashboard-card h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--primary-color);
+}
+
+.card-value {
+    margin: 0;
+    font-size: 2.4rem;
+    font-weight: 700;
+}
+
+#card-active .card-value {
+    color: var(--success-color);
+}
+
+#card-forbidden .card-value {
+    color: var(--warning-color);
+}
+
+#card-down .card-value {
+    color: var(--danger-color);
+}
+
+.dashboard-visualizations {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 20px;
+}
+
+.dashboard-chart {
+    background: white;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.dashboard-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.dashboard-section-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: var(--primary-color);
+}
+
+.dashboard-chart-subtitle {
+    color: #6c757d;
+    font-size: 0.85rem;
+}
+
+.dashboard-links {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.dashboard-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: #007bff;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.dashboard-link::after {
+    content: '→';
+    transition: transform 0.2s ease;
+}
+
+.dashboard-link:hover::after {
+    transform: translateX(4px);
+}
+
 .container {
     display: grid;
     gap: 20px;
@@ -316,6 +429,9 @@ body {
     .container {
         grid-template-columns: 1fr;
     }
+    .dashboard {
+        padding: 20px 15px;
+    }
     .systems-grid {
         grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
     }
@@ -334,6 +450,10 @@ body {
         flex-direction: column;
         gap: 10px;
         text-align: center;
+    }
+    .dashboard-section-header {
+        flex-direction: column;
+        align-items: flex-start;
     }
     .filter-container {
         flex-direction: column;

--- a/status_monitor/monitor/templates/monitor/index.html
+++ b/status_monitor/monitor/templates/monitor/index.html
@@ -18,10 +18,44 @@
         <span class="header-text">Desenvolvido por Pedro Amelotti, Equipe de Tecnologia XMX<br /><a href="{% url 'admin:index' %}" style="color: aliceblue; text-align: right;">Admin</a></span>
     </header>
 
-    <div class="container" id="main-container">
-        <!-- onde os sistemas serão exibidos de forma dinâmica -->
-    </div> 
-    
+    <main>
+        <section class="dashboard" id="dashboard">
+            <div class="dashboard-cards">
+                <article class="dashboard-card" id="card-active">
+                    <h2>Sites ativos</h2>
+                    <p class="card-value" id="active-count">0</p>
+                </article>
+                <article class="dashboard-card" id="card-forbidden">
+                    <h2>Sites proibidos</h2>
+                    <p class="card-value" id="forbidden-count">0</p>
+                </article>
+                <article class="dashboard-card" id="card-down">
+                    <h2>Sites fora do ar</h2>
+                    <p class="card-value" id="down-count">0</p>
+                </article>
+            </div>
+
+            <div class="dashboard-visualizations">
+                <div class="dashboard-chart">
+                    <header class="dashboard-section-header">
+                        <h2>Sistemas com mais indisponibilidades</h2>
+                        <span class="dashboard-chart-subtitle">Tempo total fora do ar (min)</span>
+                    </header>
+                    <canvas id="downtime-chart" aria-label="Tempo de indisponibilidade por sistema" role="img"></canvas>
+                </div>
+
+                <div class="dashboard-links">
+                    <a id="detail-link" href="#main-container" class="dashboard-link">Ver lista detalhada de sites</a>
+                </div>
+            </div>
+        </section>
+
+        <div class="container" id="main-container">
+            <!-- onde os sistemas serão exibidos de forma dinâmica -->
+        </div>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="{% static 'scripts.js' %}"></script>
 </body>
 </html>

--- a/status_monitor/monitor/urls.py
+++ b/status_monitor/monitor/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     # path('status/', views.status, name='status'),
     path('systems_list/', views.systems_list, name='systems_list'),  # nova rota
     path('system_status/', views.system_status, name='system_status'),  # nova rota
+    path('dashboard_summary/', views.dashboard_summary, name='dashboard_summary'),
     # path('check_all_statuses/', views.check_all_statuses, name='check_all_statuses'),
 ]

--- a/status_monitor/monitor/views.py
+++ b/status_monitor/monitor/views.py
@@ -1,67 +1,29 @@
-# Create your views here.
 import logging
-from datetime import datetime
+from datetime import timedelta
 
 import requests
 from django.conf import settings
 from django.core.cache import cache
+from django.db import models
+from django.db.models import ExpressionWrapper, F, Q, Sum, Value
+from django.db.models.functions import Coalesce
 from django.http import JsonResponse
 from django.shortcuts import render
+from django.utils import timezone
 from django.utils.text import slugify
 from django.views.decorators.http import require_GET
 
-from .models import Server
+from .models import (
+    Server,
+    System,
+    SystemDowntime,
+    SystemStatus,
+    SystemStatusHistory,
+)
 
 
 logger = logging.getLogger(__name__)
 
-# Lista de domínios para o primeiro servidor (198.211.109.216)
-# domains_server1 = [
-#     "adc.presgera.com", "arialief.com", "beard.presgera.com", "bg.arialief.com",
-#     "bg.en.presgera.com", "bg.feilaira.com", "bg.garaherb.com", "bg.goldenfrib.com",
-#     "bg.keskara.online", "bg.laellium.com", "bg.presgera.com", "bg.sciatilief.com",
-#     "blog.arialief.com", "cb.arialief.com", "cb.en.presgera.com", "cb.feilaira.com",
-#     "cb.goldenfrib.com", "cb.laellium.com", "cb.sciatilief.com", "cp.arialief.com",
-#     "cp.cucudrops.com", "cp.en.presgera.com", "cp.feilaira.com", "cp.goldenfrib.com",
-#     "cp.keskara.online", "cp.laellium.com", "cp.presgera.com", "cucudrops.com",
-#     "ds.arialief.com", "ds.en.presgera.com", "ds.feilaira.com", "ds.garaherb.com",
-#     "ds.laellium.com", "faq.arialief.com", "feilaira.com", "garaherb.com",
-#     "get.arialief.com", "get.garaherb.com", "get.goldenfrib.com", "get.keskara.online",
-#     "get.laellium.com", "get.presgera.com", "goldenfrib.com", "hml.arialief.com",
-#     "hml.cucudrops.com", "hml.feilaira.com", "hml.garaherb.com", "hml.goldenfrib.com",
-#     "hml.keskara.online", "hml.laellium.com", "hml.presgera.com", "hml.sciatilief.com",
-#     "homologacao.arialief.com", "idea.yufalti.com", "jan.yufalti.com", "keskara.online",
-#     "la.yufalti.com", "laellium.com", "lal.yufalti.com", "lct.presgera.com",
-#     "lee.yufalti.com", "mb1.yufalti.com", "media.presgera.com", "mioralab.com",
-#     "mrock.yufalti.com", "presgera.com", "sciatilief.com", "xmxcorp.com", "yufalti.com"
-# ]
-
-# # Lista de domínios para o segundo servidor (198.211.109.215)
-# domains_server2 = [
-#     "adc.yufalti.com", "adc.zurylix.com", "alitoryn.com", "alphacur.com", "ariomyx.com",
-#     "basmontex.com", "beard.blinzador.com", "beard.kymezol.com", "bg.alphacur.com",
-#     "bg.blinzador.com", "bg.korvizol.com", "bg.kymezol.com", "bg.memyts.com",
-#     "bg.sc.alphacur.com", "blinzador.com", "cb.alphacur.com", "cb.blinzador.com",
-#     "cb.kymezol.com", "ceramiri.com", "dry.yufalti.com", "ds.alphacur.com",
-#     "ds.blinzador.com", "ds.kymezol.com", "ds.memyts.com", "elm.kryvenonline.com",
-#     "eln.kryvenonline.com", "en.alphacur.com", "everwellinsights.com", "farulena.com",
-#     "get.alphacur.com", "get.basmontex.com", "get.blinzador.com", "get.kymezol.com",
-#     "get.memyts.com", "get.zerevest.com", "hml.alitoryn.com", "hml.alphacur.com",
-#     "hml.ariomyx.com", "hml.blinzador.com", "hml.karylief.com", "hml.korvizol.com",
-#     "hml.kymezol.com", "hml.levhyn.com", "hml.mahgryn.com", "hml.memyts.com",
-#     "hml.nathurex.com", "hml.zerevest.com", "ic1.zurylix.com", "karylief.com",
-#     "korvizol.com", "kymezol.com", "lee1.zurylix.com", "lee2.zurylix.com", "levhyn.com",
-#     "lj.yundelo.com", "mahgryn.com", "mb2.yufalti.com", "memyts.com", "nathurex.com",
-#     "rock.kymezol.com", "thehealthnow.com", "thewellnesswize.com", "thewellspecialists.com",
-#     "wdl.yufalti.com", "wdl.zurylix.com", "wenzora.com", "yundelo.com", "zalovira.com",
-#     "zerevest.com", "zurylix.com"
-# ]
-
-# # Agrupando os sistemas com os nomes corretos dos servidores
-# servers = {
-#     "servidor-produtos-principais": [{"name": d, "url": f"http://{d}"} for d in domains_server1],
-#     "servidor-produtos-principais-2": [{"name": d, "url": f"http://{d}"} for d in domains_server2],
-# }
 
 def check_url(url):
     try:
@@ -69,6 +31,7 @@ def check_url(url):
         return response.status_code
     except requests.RequestException:
         return 0  # Retorna 0 em caso de erro de conexão ou timeout
+
 
 def get_status_string(status_code):
     if status_code == 200:
@@ -111,7 +74,7 @@ def notify_discord(name: str, url: str, status_str: str, status_code: int | None
                 status=status_str,
                 url=url,
                 code=readable_code,
-                checked_at=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                checked_at=timezone.now().strftime("%Y-%m-%d %H:%M:%S"),
             )
         }
     elif last_status in failure_statuses and status_str == "UP":
@@ -123,7 +86,7 @@ def notify_discord(name: str, url: str, status_str: str, status_code: int | None
             ).format(
                 name=name,
                 url=url,
-                checked_at=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                checked_at=timezone.now().strftime("%Y-%m-%d %H:%M:%S"),
             )
         }
 
@@ -136,6 +99,7 @@ def notify_discord(name: str, url: str, status_str: str, status_code: int | None
     except requests.RequestException:
         logger.exception("Falha ao enviar notificação para o Discord para %s", name)
 
+
 def index(request):
     return render(request, 'monitor/index.html')
 
@@ -143,15 +107,25 @@ def index(request):
 @require_GET
 def systems_list(request):
     servers_data = {}
-    # Busca todos os servidores do banco de dados
     for server in Server.objects.all():
-        # Para cada servidor, busca os sistemas associados
-        systems = server.systems.all()
-        servers_data[server.name] = [
-            {"name": system.name, "url": system.url}
-            for system in systems
-        ]
+        systems = server.systems.select_related("current_status").all()
+        servers_data[server.name] = []
+        for system in systems:
+            current_status = getattr(system, "current_status", None)
+            servers_data[server.name].append(
+                {
+                    "name": system.name,
+                    "url": system.url,
+                    "status": current_status.status if current_status else None,
+                    "checked_at": timezone.localtime(current_status.checked_at).strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                    if current_status
+                    else None,
+                }
+            )
     return JsonResponse(servers_data)
+
 
 @require_GET
 def system_status(request):
@@ -162,12 +136,110 @@ def system_status(request):
 
     status_code = check_url(url)
     status_str = get_status_string(status_code)
+    now = timezone.now()
 
     notify_discord(name, url, status_str, status_code)
 
-    return JsonResponse({
-        "name": name,
-        "url": url,
-        "status": status_str,
-        "checked_at": datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    })
+    system = System.objects.filter(name=name).first()
+    if system:
+        SystemStatus.objects.update_or_create(
+            system=system,
+            defaults={
+                "status": status_str,
+                "status_code": status_code if status_code is not None else None,
+                "checked_at": now,
+            },
+        )
+
+        SystemStatusHistory.objects.create(
+            system=system,
+            status=status_str,
+            status_code=status_code if status_code is not None else None,
+            checked_at=now,
+        )
+
+        active_downtime = SystemDowntime.objects.filter(
+            system=system, ended_at__isnull=True
+        ).first()
+
+        if status_str == "UP":
+            if active_downtime:
+                active_downtime.ended_at = now
+                active_downtime.save(update_fields=["ended_at"])
+        elif status_str in {"DOWN", "FORBIDDEN"}:
+            if active_downtime:
+                if active_downtime.status != status_str:
+                    active_downtime.status = status_str
+                    active_downtime.save(update_fields=["status"])
+            else:
+                SystemDowntime.objects.create(
+                    system=system,
+                    status=status_str,
+                    started_at=now,
+                )
+
+    return JsonResponse(
+        {
+            "name": name,
+            "url": url,
+            "status": status_str,
+            "checked_at": timezone.localtime(now).strftime("%Y-%m-%d %H:%M:%S"),
+        }
+    )
+
+
+@require_GET
+def dashboard_summary(request):
+    now = timezone.now()
+    statuses = SystemStatus.objects.all()
+    counts = {
+        "active": statuses.filter(status="UP").count(),
+        "forbidden": statuses.filter(status="FORBIDDEN").count(),
+        "down": statuses.exclude(status__in=["UP", "FORBIDDEN"]).count(),
+    }
+
+    try:
+        days = int(request.GET.get("days", 30))
+    except (TypeError, ValueError):
+        days = 30
+
+    since = now - timedelta(days=days)
+
+    relevant_downtimes = SystemDowntime.objects.filter(
+        Q(started_at__gte=since)
+        | Q(ended_at__gte=since)
+        | Q(ended_at__isnull=True)
+    )
+
+    duration_expr = ExpressionWrapper(
+        Coalesce(F("ended_at"), Value(now, output_field=models.DateTimeField()))
+        - F("started_at"),
+        output_field=models.DurationField(),
+    )
+
+    downtime_totals = (
+        relevant_downtimes.annotate(duration=duration_expr)
+        .values("system__name")
+        .annotate(total_duration=Sum("duration"))
+        .order_by("-total_duration")[:10]
+    )
+
+    chart_data = []
+    for item in downtime_totals:
+        total_duration = item.get("total_duration")
+        if total_duration is None:
+            continue
+        chart_data.append(
+            {
+                "name": item["system__name"],
+                "total_minutes": round(total_duration.total_seconds() / 60, 2),
+            }
+        )
+
+    return JsonResponse(
+        {
+            "counts": counts,
+            "downtime_chart": chart_data,
+            "detail_anchor": "#main-container",
+        }
+    )


### PR DESCRIPTION
## Summary
- add persistent status, status history, and downtime tracking models with a dashboard summary API
- implement a new dashboard UI with metric cards, downtime chart, and cached client state to keep timers consistent
- store migrations in version control and extend static assets for the new analytics view

## Testing
- Unable to run tests (missing Django dependency in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e507bc55d88328a14657bc6e01e851